### PR TITLE
allow overriding non-str values

### DIFF
--- a/layered_vision/cli.py
+++ b/layered_vision/cli.py
@@ -1,8 +1,9 @@
 import argparse
 import logging
+import re
 import os
 from abc import ABC, abstractmethod
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = "3"
 
@@ -37,11 +38,24 @@ def add_common_arguments(parser: argparse.ArgumentParser):
     )
 
 
+def parse_value_expression(value_str: str) -> Union[str, int, float, bool]:
+    if value_str.lower() == 'false':
+        return False
+    if value_str.lower() == 'true':
+        return True
+    if re.match(r'^\d+$', value_str):
+        return int(value_str)
+    if re.match(r'^\d+\.\d+$', value_str):
+        return float(value_str)
+    return value_str
+
+
 def parse_set_value(text: str) -> Tuple[str, str]:
     try:
         key, value = text.split('=', maxsplit=1)
     except ValueError as exc:
         raise ValueError('value expected, format: <layer id>.<prop name>=<value>') from exc
+    value = parse_value_expression(value)
     try:
         layer_id, prop_name = key.split('.', maxsplit=1)
     except ValueError as exc:

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -5,6 +5,7 @@ import cv2
 import pytest
 
 from layered_vision.cli import (
+    parse_value_expression,
     parse_set_value,
     get_merged_set_values,
     main
@@ -27,11 +28,35 @@ def _load_image(path: str):
     return image
 
 
+class TestParseValueExpression:
+    def test_should_parse_str(self):
+        assert parse_value_expression('abc') == 'abc'
+
+    def test_should_parse_int(self):
+        assert parse_value_expression('30') == 30
+
+    def test_should_parse_float(self):
+        assert parse_value_expression('30.1') == 30.1
+
+    def test_should_parse_false(self):
+        assert parse_value_expression('false') is False
+
+    def test_should_parse_true(self):
+        assert parse_value_expression('true') is True
+
+
 class TestParseSetValue:
     def test_should_parse_simple_expression(self):
         assert parse_set_value('in.input_path=/path/to/input') == {
             'in': {
                 'input_path': '/path/to/input'
+            }
+        }
+
+    def test_should_parse_int_value(self):
+        assert parse_set_value('in.fps=30') == {
+            'in': {
+                'fps': 30
             }
         }
 


### PR DESCRIPTION
Currently it wouldn't be possible to change the fps via the CLI overrides because they only accept string values.
This fixes it by also parsing for int, float of boolean values.