### PR TITLE
reloadable config

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ python -m layered_vision start \
 
 Note: you may need to specify the fps
 
+If a local configuration file was specified, the application will attempt to reload it on change.
+
 ### Docker Usage
 
 You could also use the Docker image if you prefer.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The following inputs are currently supported:
 | image | Static image (e.g. `.png`) |
 | video | Video (e.g. `.mp4`) |
 | webcam | Linux Webcam (`/dev/videoN`) |
-| youtube | YouTube stream (e.g. `https://youtu.be/yswkqEBio2k`,  see [example config](https://github.com/de-code/layered-vision/tree/develop/example-config/display-video-bodypix-replace-background-youtube.yml)) |
+| youtube | YouTube stream (e.g. `https://youtu.be/f0cGgOv3l4c`,  see [example config](https://github.com/de-code/layered-vision/tree/develop/example-config/display-video-bodypix-replace-background-youtube.yml)) |
 | mss | Screen capture using [mss](https://python-mss.readthedocs.io/index.html) (see [example config](https://github.com/de-code/layered-vision/tree/develop/example-config/display-video-bodypix-replace-background-mss.yml)) |
 
 The `input_path` may point to a remote location (as is the case with [all examples](https://github.com/de-code/layered-vision/tree/develop/example-config)). In that case it will be downloaded and cached locally.
@@ -210,7 +210,7 @@ You could also try replacing the background with a YouTube stream:
 python -m layered_vision start \
   --config-file \
   "https://raw.githubusercontent.com/de-code/layered-vision/develop/example-config/webcam-bodypix-replace-background-to-v4l2loopback.yml" \
-  --set bg.input_path="https://youtu.be/yswkqEBio2k" \
+  --set bg.input_path="https://youtu.be/f0cGgOv3l4c" \
   --set bg.fps=30 \
   --set in.input_path="/dev/video0" \
   --set out.output_path="/dev/video2"

--- a/layered_vision/config.py
+++ b/layered_vision/config.py
@@ -120,6 +120,14 @@ class PropsConfig:
             self.props
         )
 
+    def __eq__(self, other):
+        if isinstance(other, PropsConfig):
+            return self.props == other.props
+        return super().__eq__(other)
+
+    def __hash__(self):
+        return hash(self.props)
+
 
 class LayerConfig(PropsConfig):
     @staticmethod
@@ -161,7 +169,7 @@ class AppConfig:
             yield from _iter_find_nested_layer_props(layer.props)
 
     def __repr__(self):
-        return '%s(layer=%r)' % (
+        return '%s(layers=%r)' % (
             type(self).__name__,
             self.layers
         )

--- a/layered_vision/filters/api.py
+++ b/layered_vision/filters/api.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 from importlib import import_module
-from typing import NamedTuple
+from typing import NamedTuple, Optional, Tuple
 
 import numpy as np
 
@@ -34,6 +34,10 @@ class LayerFilter(ABC):
     def filter(self, image_array: ImageArray) -> ImageArray:
         pass
 
+    @abstractmethod
+    def set_config(self, layer_config: LayerConfig):
+        pass
+
 
 class AbstractLayerFilter(LayerFilter):
     def __init__(
@@ -56,34 +60,55 @@ class AbstractLayerFilter(LayerFilter):
     def filter(self, image_array: ImageArray) -> ImageArray:
         return self.do_filter(resolve_lazy_image(image_array))
 
+    def on_config_changed(self, layer_config: LayerConfig):
+        pass
+
+    def set_config(self, layer_config: LayerConfig):
+        if self.layer_config.props == layer_config.props:
+            return
+        self.layer_config = layer_config
+        self.on_config_changed(layer_config)
+
 
 class ChromaKeyFilter(AbstractLayerFilter):
+    class Config(NamedTuple):
+        rgb_key: Tuple[int, int, int]
+        threshold: int
+
     def __init__(self, layer_config: LayerConfig, **kwargs):
-        self.rgb_key = (
-            layer_config.get_int('red', 0),
-            layer_config.get_int('green', 0),
-            layer_config.get_int('blue', 0)
-        )
-        self.threshold = layer_config.get_int('threshold') or 0
-        LOGGER.info('chroma key: %s', self.rgb_key)
+        self.chroma_key_config = self.parse_chroma_key_config(layer_config)
         super().__init__(layer_config, **kwargs)
 
+    def parse_chroma_key_config(self, layer_config: LayerConfig) -> Config:
+        config = ChromaKeyFilter.Config(
+            rgb_key=(
+                layer_config.get_int('red', 0),
+                layer_config.get_int('green', 0),
+                layer_config.get_int('blue', 0)
+            ),
+            threshold=layer_config.get_int('threshold') or 0
+        )
+        LOGGER.info('chroma key: %s', config)
+        return config
+
+    def on_config_changed(self, layer_config: LayerConfig):
+        super().on_config_changed(layer_config)
+        self.chroma_key_config = self.parse_chroma_key_config(layer_config)
+
     def do_filter(self, image_array: ImageArray) -> ImageArray:
-        if not self.threshold:
-            mask = np.all(image_array[:, :, :3] != self.rgb_key, axis=-1).astype(np.uint8) * 255
+        rgb_key = self.chroma_key_config.rgb_key
+        if not self.chroma_key_config.threshold:
+            mask = np.all(image_array[:, :, :3] != rgb_key, axis=-1).astype(np.uint8) * 255
         else:
             mask = (
-                np.mean(np.abs(np.asarray(image_array)[:, :, :3] - self.rgb_key), axis=-1)
-                > self.threshold
+                np.mean(np.abs(np.asarray(image_array)[:, :, :3] - rgb_key), axis=-1)
+                > self.chroma_key_config.threshold
             ).astype(np.uint8) * 255
         LOGGER.debug('mask.shape: %s', mask.shape)
         return get_image_with_alpha(
             image_array,
             mask
         )
-
-    # def filter(self, image_array: ImageArray) -> ImageArray:
-    #     return self.do_filter(image_array)
 
 
 CHANNEL_NAMES = ['red', 'green', 'blue', 'alpha']
@@ -92,13 +117,20 @@ CHANNEL_NAMES = ['red', 'green', 'blue', 'alpha']
 class AbstractOptionalChannelFilter(AbstractLayerFilter):
     def __init__(self, layer_config: LayerConfig, **kwargs):
         super().__init__(layer_config, **kwargs)
-        self.channel = layer_config.get_str('channel')
+        self.channel_index = self.parse_channel_index(layer_config)
+
+    def parse_channel_index(self, layer_config: LayerConfig) -> Optional[int]:
+        channel = layer_config.get_str('channel')
         try:
-            self.channel_index = CHANNEL_NAMES.index(self.channel) if self.channel else None
+            return CHANNEL_NAMES.index(channel) if channel else None
         except IndexError as exc:
             raise RuntimeError('invalid channel: %r (expected one of %s)' % (
-                self.channel, CHANNEL_NAMES
+                channel, CHANNEL_NAMES
             )) from exc
+
+    def on_config_changed(self, layer_config: LayerConfig):
+        super().on_config_changed(layer_config)
+        self.channel_index = self.parse_channel_index(layer_config)
 
     @abstractmethod
     def do_channel_filter(self, image_array: ImageArray) -> ImageArray:
@@ -109,7 +141,7 @@ class AbstractOptionalChannelFilter(AbstractLayerFilter):
             return self.do_channel_filter(image_array)
         channel_count = image_array.shape[2]
         if self.channel_index >= channel_count:
-            LOGGER.debug('image has no channel: %d (%r)', self.channel_index, self.channel)
+            LOGGER.debug('image has no channel: %d', self.channel_index)
             return self.do_channel_filter(image_array)
         image_channel = np.expand_dims(image_array[:, :, self.channel_index], axis=-1)
         filtered_image_channel = self.do_channel_filter(image_channel)

--- a/layered_vision/filters/api.py
+++ b/layered_vision/filters/api.py
@@ -1,11 +1,13 @@
 import logging
 from abc import ABC, abstractmethod
 from importlib import import_module
+from typing import NamedTuple
 
 import numpy as np
 
 import cv2
 
+from ..utils.timer import LoggingTimer
 from ..utils.image import (
     ImageArray,
     ImageSize,
@@ -16,10 +18,15 @@ from ..utils.image import (
     erode_image,
     dilate_image
 )
+from ..utils.lazy_image import resolve_lazy_image
 from ..config import LayerConfig
 
 
 LOGGER = logging.getLogger(__name__)
+
+
+class FilterContext(NamedTuple):
+    timer: LoggingTimer
 
 
 class LayerFilter(ABC):
@@ -29,8 +36,25 @@ class LayerFilter(ABC):
 
 
 class AbstractLayerFilter(LayerFilter):
-    def __init__(self, layer_config: LayerConfig, **__):
+    def __init__(
+        self,
+        layer_config: LayerConfig,
+        filter_context: FilterContext,
+        **__
+    ):
         self.layer_config = layer_config
+        self.context = filter_context
+
+    @property
+    def filter_id(self):
+        return self.layer_config.get('id')
+
+    @abstractmethod
+    def do_filter(self, image_array: ImageArray) -> ImageArray:
+        pass
+
+    def filter(self, image_array: ImageArray) -> ImageArray:
+        return self.do_filter(resolve_lazy_image(image_array))
 
 
 class ChromaKeyFilter(AbstractLayerFilter):
@@ -58,8 +82,8 @@ class ChromaKeyFilter(AbstractLayerFilter):
             mask
         )
 
-    def filter(self, image_array: ImageArray) -> ImageArray:
-        return self.do_filter(image_array)
+    # def filter(self, image_array: ImageArray) -> ImageArray:
+    #     return self.do_filter(image_array)
 
 
 CHANNEL_NAMES = ['red', 'green', 'blue', 'alpha']
@@ -80,7 +104,7 @@ class AbstractOptionalChannelFilter(AbstractLayerFilter):
     def do_channel_filter(self, image_array: ImageArray) -> ImageArray:
         pass
 
-    def filter(self, image_array: ImageArray) -> ImageArray:
+    def do_filter(self, image_array: ImageArray) -> ImageArray:
         if self.channel_index is None:
             return self.do_channel_filter(image_array)
         channel_count = image_array.shape[2]
@@ -182,7 +206,8 @@ FILTER_CLASS_BY_NAME_MAP = {
 
 
 def create_filter(
-    layer_config: LayerConfig
+    layer_config: LayerConfig,
+    filter_context: FilterContext
 ) -> LayerFilter:
     filter_name = layer_config.get_str('filter')
     filter_class = FILTER_CLASS_BY_NAME_MAP.get(filter_name)
@@ -192,5 +217,5 @@ def create_filter(
         filter_class = _filter_class
         FILTER_CLASS_BY_NAME_MAP[filter_name] = _filter_class
     if filter_class:
-        return filter_class(layer_config)
+        return filter_class(layer_config, filter_context=filter_context)
     raise RuntimeError('unrecognised filter: %r' % filter_name)

--- a/layered_vision/filters/bodypix.py
+++ b/layered_vision/filters/bodypix.py
@@ -1,6 +1,6 @@
 import logging
 from time import time
-from typing import List, Optional
+from typing import List, NamedTuple, Optional
 
 import numpy as np
 
@@ -20,29 +20,54 @@ LOGGER = logging.getLogger(__name__)
 
 
 class BodyPixFilter(AbstractLayerFilter):
+    class Config(NamedTuple):
+        model_path: str
+        threshold: float
+        internal_resolution: float
+        cache_model_result_secs: float
+        parts: List[str]
+
     def __init__(self, layer_config: LayerConfig, **kwargs):
         super().__init__(layer_config, **kwargs)
-        self.model_path = (
-            layer_config.get_str('model_path')
-            or BodyPixModelPaths.MOBILENET_FLOAT_50_STRIDE_16
-        )
+        self.bodypix_config = self.parse_bodypix_config(layer_config)
         self._bodypix_model = None
-        self.threshold = layer_config.get_float('threshold') or 0.50
-        self.internal_resolution = layer_config.get_float('internal_resolution') or 0.50
-        self.cache_model_result_secs = (
-            layer_config.get_float('cache_model_result_secs') or 0.0
-        )
-        self.parts: List[str] = list(
-            layer_config.get_str_list('parts') or []
-        )
         self._bodypix_result_cache = None
         self._bodypix_result_cache_time: Optional[float] = None
 
+    def parse_bodypix_config(self, layer_config: LayerConfig) -> Config:
+        config = BodyPixFilter.Config(
+            model_path=(
+                layer_config.get_str('model_path')
+                or BodyPixModelPaths.MOBILENET_FLOAT_50_STRIDE_16
+            ),
+            threshold=layer_config.get_float('threshold') or 0.50,
+            internal_resolution=layer_config.get_float('internal_resolution') or 0.50,
+            cache_model_result_secs=(
+                layer_config.get_float('cache_model_result_secs') or 0.0
+            ),
+            parts=list(
+                layer_config.get_str_list('parts') or []
+            )
+        )
+        LOGGER.info('bodypix filter config: %s', config)
+        return config
+
+    def on_config_changed(self, layer_config: LayerConfig):
+        super().on_config_changed(layer_config)
+        bodypix_config = self.parse_bodypix_config(layer_config)
+        if (
+            bodypix_config.model_path != self.bodypix_config.model_path
+            or bodypix_config.internal_resolution != self.bodypix_config.internal_resolution
+        ):
+            # we need to reload the model
+            self._bodypix_model = None
+        self.bodypix_config = bodypix_config
+
     def load_bodypix_model(self) -> BodyPixModelWrapper:
-        LOGGER.info('loading bodypix model: %s', self.model_path)
+        LOGGER.info('loading bodypix model: %s', self.bodypix_config.model_path)
         bodypix_model = load_model(
-            download_model(self.model_path),
-            internal_resolution=self.internal_resolution
+            download_model(self.bodypix_config.model_path),
+            internal_resolution=self.bodypix_config.internal_resolution
         )
         LOGGER.info('bodypix internal resolution: %s', bodypix_model.internal_resolution)
         return bodypix_model
@@ -57,7 +82,9 @@ class BodyPixFilter(AbstractLayerFilter):
         current_time = time()
         if (
             self._bodypix_result_cache is not None
-            and current_time < self._bodypix_result_cache_time + self.cache_model_result_secs
+            and current_time < (
+                self._bodypix_result_cache_time + self.bodypix_config.cache_model_result_secs
+            )
         ):
             return self._bodypix_result_cache
         self._bodypix_result_cache = self.bodypix_model.predict_single(image_array)
@@ -66,9 +93,9 @@ class BodyPixFilter(AbstractLayerFilter):
 
     def do_filter(self, image_array: ImageArray) -> ImageArray:
         result = self.get_bodypix_result(image_array)
-        mask = result.get_mask(threshold=self.threshold, dtype=np.uint8)
-        if self.parts:
-            mask = result.get_part_mask(mask, part_names=self.parts)
+        mask = result.get_mask(threshold=self.bodypix_config.threshold, dtype=np.uint8)
+        if self.bodypix_config.parts:
+            mask = result.get_part_mask(mask, part_names=self.bodypix_config.parts)
         mask = np.multiply(mask, 255)
         LOGGER.debug('mask.shape: %s', mask.shape)
         return get_image_with_alpha(

--- a/layered_vision/filters/bodypix.py
+++ b/layered_vision/filters/bodypix.py
@@ -64,7 +64,7 @@ class BodyPixFilter(AbstractLayerFilter):
         self._bodypix_result_cache_time = current_time
         return self._bodypix_result_cache
 
-    def filter(self, image_array: ImageArray) -> ImageArray:
+    def do_filter(self, image_array: ImageArray) -> ImageArray:
         result = self.get_bodypix_result(image_array)
         mask = result.get_mask(threshold=self.threshold, dtype=np.uint8)
         if self.parts:

--- a/layered_vision/filters/composite.py
+++ b/layered_vision/filters/composite.py
@@ -1,0 +1,27 @@
+import logging
+
+from layered_vision.utils.image import ImageArray, combine_images
+from layered_vision.utils.lazy_image import LazyImageList
+from layered_vision.filters.api import AbstractLayerFilter
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CompositeFilter(AbstractLayerFilter):
+    def do_filter(self, image_array: ImageArray) -> ImageArray:
+        assert isinstance(image_array, LazyImageList)
+        lazy_images = image_array.images
+        images = list(reversed([
+            lazy_image.image
+            for lazy_image in reversed(lazy_images)
+        ]))
+        with self.context.timer.enter_step(f'{self.filter_id}.combine'):
+            return combine_images(images)
+
+    def filter(self, image_array: ImageArray) -> ImageArray:
+        # don't resolve lazy image
+        return self.do_filter(image_array)
+
+
+FILTER_CLASS = CompositeFilter

--- a/layered_vision/resolved_config.py
+++ b/layered_vision/resolved_config.py
@@ -1,0 +1,130 @@
+from typing import Dict, List, Optional
+
+from layered_vision.config import AppConfig, LayerConfig
+
+
+class ResolvedLayerConfig(LayerConfig):
+    def __init__(self, props: dict, default_input_layer: 'ResolvedLayerConfig' = None):
+        super().__init__(props)
+        self.layer_id = props['id']
+        self.input_layers: List[ResolvedLayerConfig] = []
+        if default_input_layer and not self.is_no_source:
+            self.input_layers.append(default_input_layer)
+
+    @property
+    def input_layer_ids(self):
+        return [layer_config.layer_id for layer_config in self.input_layers]
+
+    @property
+    def is_enabled(self) -> bool:
+        return self.get_bool('enabled', True)
+
+    @property
+    def is_no_source(self) -> bool:
+        return self.get_bool('no_source', False)
+
+    @property
+    def is_output_layer(self) -> bool:
+        return bool(self.get('output_path'))
+
+    @property
+    def is_input_layer(self) -> bool:
+        return bool(self.get('input_path'))
+
+    @property
+    def is_filter_layer(self) -> bool:
+        return bool(self.get('filter'))
+
+
+class ResolvedAppConfig:
+    def __init__(self, app_config: AppConfig):
+        self.layer_by_id: Dict[str, ResolvedLayerConfig] = {}
+        self.layers: List[ResolvedLayerConfig] = []
+        self._add_layers_recursively(app_config.layers)
+
+    def _add_resolved_layer(
+        self,
+        resolved_layer_config: ResolvedLayerConfig,
+    ) -> ResolvedLayerConfig:
+        self.layers.append(resolved_layer_config)
+        self.layer_by_id[resolved_layer_config.layer_id] = resolved_layer_config
+        return resolved_layer_config
+
+    def _add_layers_recursively(
+        self,
+        layers: List[LayerConfig],
+        default_id_prefix: str = '',
+        default_input_layer: Optional[ResolvedLayerConfig] = None
+    ) -> List[ResolvedLayerConfig]:
+        resolved_layers: List[ResolvedLayerConfig] = []
+        for layer_index, layer_config in enumerate(layers):
+            if not layer_config.get_bool('enabled', True):
+                continue
+            resolved_layer_config = self._add_layer_recursively(
+                layer_config,
+                default_id=f'{default_id_prefix}l{layer_index}',
+                default_input_layer=default_input_layer
+            )
+            if not resolved_layer_config.is_output_layer:
+                default_input_layer = resolved_layer_config
+                resolved_layers.append(resolved_layer_config)
+        return resolved_layers
+
+    def _add_layer_recursively(
+        self,
+        layer_config: LayerConfig,
+        default_id: str,
+        default_input_layer: Optional[ResolvedLayerConfig]
+    ) -> ResolvedLayerConfig:
+        layer_id = layer_config.get('id') or default_id
+        branches = layer_config.get('branches')
+        if branches:
+            return self._add_branches_recursively(
+                layer_config,
+                layer_id=layer_id,
+                default_input_layer=default_input_layer
+            )
+        resolved_layer_config = ResolvedLayerConfig({
+            **layer_config.props,
+            'id': layer_id
+        }, default_input_layer=default_input_layer)
+        return self._add_resolved_layer(resolved_layer_config)
+
+    def _add_branch_recursively(
+        self,
+        layer_config: LayerConfig,
+        default_id: str,
+        default_input_layer: Optional[ResolvedLayerConfig]
+    ):
+        layers: Optional[List[dict]] = layer_config.get_list('layers')
+        assert layers
+        resolved_layers = self._add_layers_recursively(
+            [LayerConfig(props) for props in layers],
+            default_id_prefix=default_id,
+            default_input_layer=default_input_layer
+        )
+        return resolved_layers[-1]
+
+    def _add_branches_recursively(
+        self,
+        layer_config: LayerConfig,
+        layer_id: str,
+        default_input_layer: ResolvedLayerConfig
+    ):
+        branches: Optional[List[dict]] = layer_config.get_list('branches')
+        assert branches
+        branch_layers = [
+            self._add_branch_recursively(
+                LayerConfig(branch_config),
+                default_id=f'{layer_id}b{branch_index}',
+                default_input_layer=default_input_layer
+            )
+            for branch_index, branch_config in enumerate(branches)
+        ]
+        resolved_layer_config = ResolvedLayerConfig({
+            **layer_config.props,
+            'id': layer_id,
+            'filter': 'composite'
+        })
+        resolved_layer_config.input_layers = branch_layers
+        return self._add_resolved_layer(resolved_layer_config)

--- a/layered_vision/utils/lazy_image.py
+++ b/layered_vision/utils/lazy_image.py
@@ -1,0 +1,60 @@
+from abc import ABC, abstractmethod
+from typing import Callable, List, Optional
+
+from .image import ImageArray
+
+
+T_ImageFactory = Callable[[], ImageArray]
+
+
+class LazyImageProxy(ABC):
+    @abstractmethod
+    def get_image(self):
+        pass
+
+    @property
+    def image(self):
+        return self.get_image()
+
+    @property
+    def dtype(self):
+        return self.image.dtype
+
+    @property
+    def shape(self):
+        return self.image.shape
+
+    def __len__(self):
+        return len(self.image)
+
+    def __getitem__(self, *args):
+        return self.image.__getitem__(*args)
+
+
+class LazyImage(LazyImageProxy):
+    def __init__(self, factory: T_ImageFactory):
+        self.factory = factory
+        self._image: Optional[ImageArray] = None
+
+    def get_image(self):
+        if self._image is None:
+            self._image = self.factory()
+        return self._image
+
+
+class LazyImageList(LazyImageProxy):
+    def __init__(self, factories: List[T_ImageFactory]):
+        self.images: List[LazyImage] = [
+            LazyImage(factory)
+            for factory in factories
+        ]
+
+    def get_image(self):
+        return self.images[-1].image
+
+
+def resolve_lazy_image(image) -> ImageArray:
+    try:
+        return image.image
+    except AttributeError:
+        return image

--- a/layered_vision/utils/opencv.py
+++ b/layered_vision/utils/opencv.py
@@ -142,24 +142,6 @@ def iter_read_raw_video_images(
         yield image_array
 
 
-def iter_read_raw_video_images_threaded(
-    video_capture: cv2.VideoCapture,
-    repeat: bool = False,
-    is_stopped: Callable[[], bool] = None
-) -> Iterable[ImageArray]:
-    iterable = iter_read_raw_video_images(
-        video_capture=video_capture,
-        repeat=repeat,
-        is_stopped=is_stopped
-    )
-    fps = video_capture.get(cv2.CAP_PROP_FPS)
-    if fps:
-        LOGGER.info('fps: %s', fps)
-        iterable = iter_delay_video_images_to_fps(iterable, fps=fps)
-    with ReadLatestThreadedReader(iterable) as reader:
-        yield from reader
-
-
 def iter_resize_video_images(
     video_images: Iterable[ImageArray],
     image_size: ImageSize = None,

--- a/layered_vision/utils/timer.py
+++ b/layered_vision/utils/timer.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import contextmanager
 from time import time
 from typing import Dict, List, Optional
 
@@ -27,7 +28,11 @@ class LoggingTimer:
         current_time = time()
         self.interval_start_time = current_time
 
-    def _set_current_step_name(self, step_name: str, current_time: float = None):
+    def _set_current_step_name(
+        self,
+        step_name: Optional[str],
+        current_time: float = None
+    ):
         if step_name == self.current_step_name:
             return
         if current_time is None:
@@ -53,6 +58,15 @@ class LoggingTimer:
         if step_name == self.current_step_name:
             return
         self._set_current_step_name(step_name)
+
+    @contextmanager
+    def enter_step(self, step_name: str):
+        previous_step_name = self.current_step_name
+        try:
+            self.on_step_start(step_name)
+            yield
+        finally:
+            self._set_current_step_name(previous_step_name)
 
     def on_step_end(self):
         self._set_current_step_name(None)

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -1,11 +1,20 @@
 from io import StringIO
 from pathlib import Path
-from typing import Union
+from typing import Tuple, Union
 
 import pytest
 import yaml
+import cv2
+import numpy as np
 
+from layered_vision.utils.image import ImageSize, ImageArray
 from layered_vision.app import LayeredVisionApp
+
+
+DEFAULT_IMAGE_SIZE = ImageSize(height=4, width=6)
+RGB_RED = (255, 0, 0)
+RGB_GREEN = (0, 255, 0)
+RGB_BLUE = (0, 0, 255)
 
 
 def _quote_path(path: Union[str, Path]) -> str:
@@ -18,7 +27,45 @@ def _get_yaml_text(data) -> str:
     return out.getvalue()
 
 
-class TestMain:
+def create_solid_color_image(image_size: ImageSize, rgb: Tuple[int, int, int]) -> ImageArray:
+    image = np.zeros((image_size.height, image_size.width, 3), np.uint8)
+    image[:] = rgb
+    return image
+
+
+def read_image(path: Path) -> ImageArray:
+    bgr_image = cv2.imread(str(path))
+    rgb_image = cv2.cvtColor(bgr_image, cv2.COLOR_BGR2RGB)
+    return rgb_image
+
+
+def save_image(path: Path, image: ImageArray):
+    bgr_image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
+    cv2.imwrite(str(path), bgr_image)
+    return path
+
+
+RED_IMAGE = create_solid_color_image(DEFAULT_IMAGE_SIZE, RGB_RED)
+GREEN_IMAGE = create_solid_color_image(DEFAULT_IMAGE_SIZE, RGB_GREEN)
+BLUE_IMAGE = create_solid_color_image(DEFAULT_IMAGE_SIZE, RGB_BLUE)
+
+
+@pytest.fixture(name='red_image_file')
+def _red_image_file(tmp_path: Path) -> Path:
+    return save_image(tmp_path / 'red.png', RED_IMAGE)
+
+
+@pytest.fixture(name='green_image_file')
+def _green_image_file(tmp_path: Path) -> Path:
+    return save_image(tmp_path / 'green.png', GREEN_IMAGE)
+
+
+@pytest.fixture(name='blue_image_file')
+def _blue_image_file(tmp_path: Path) -> Path:
+    return save_image(tmp_path / 'blue.png', BLUE_IMAGE)
+
+
+class TestApp:
     def test_should_configure_simple_input_output(self, temp_dir: Path):
         input_path = temp_dir / 'input.png'
         output_path = temp_dir / 'output.png'
@@ -98,3 +145,86 @@ class TestMain:
             app.reload_config()
             assert app.layer_by_id['in'].layer_config.get('input_path') == str(input_path_2)
             assert app.layer_by_id['out'] == output_layer
+
+
+class TestAppEndToEnd:
+    def test_should_copy_image(
+        self, temp_dir: Path,
+        red_image_file: Path
+    ):
+        output_path = temp_dir / 'output.png'
+        config_file = temp_dir / 'config.yml'
+        config = {
+            'layers': [{
+                'id': 'in',
+                'input_path': str(red_image_file)
+            }, {
+                'id': 'out',
+                'output_path': str(output_path)
+            }]
+        }
+        config_file.write_text(_get_yaml_text(config))
+        with LayeredVisionApp(str(config_file)) as app:
+            app.run()
+            output_image = read_image(output_path)
+            np.testing.assert_array_equal(output_image, RED_IMAGE)
+
+    def test_should_reload_config_image_input(
+        self, temp_dir: Path,
+        red_image_file: Path,
+        green_image_file: Path
+    ):
+        output_path = temp_dir / 'output.png'
+        config_file = temp_dir / 'config.yml'
+        config = {
+            'layers': [{
+                'id': 'in',
+                'input_path': str(red_image_file)
+            }, {
+                'id': 'out',
+                'output_path': str(output_path)
+            }]
+        }
+        config_file.write_text(_get_yaml_text(config))
+        with LayeredVisionApp(str(config_file)) as app:
+            app.run()
+
+            config['layers'][0]['input_path'] = str(green_image_file)
+            config_file.write_text(_get_yaml_text(config))
+            app.reload_config()
+            app.run()
+
+            output_image = read_image(output_path)
+            np.testing.assert_array_equal(output_image, GREEN_IMAGE)
+
+    def test_should_reload_config_enabled_image_input(
+        self, temp_dir: Path,
+        red_image_file: Path,
+        green_image_file: Path
+    ):
+        output_path = temp_dir / 'output.png'
+        config_file = temp_dir / 'config.yml'
+        config: dict = {
+            'layers': [{
+                'id': 'in',
+                'input_path': str(red_image_file)
+            }, {
+                'id': 'in2',
+                'input_path': str(green_image_file),
+                'enabled': False
+            }, {
+                'id': 'out',
+                'output_path': str(output_path)
+            }]
+        }
+        config_file.write_text(_get_yaml_text(config))
+        with LayeredVisionApp(str(config_file)) as app:
+            app.run()
+
+            config['layers'][1]['enabled'] = True
+            config_file.write_text(_get_yaml_text(config))
+            app.reload_config()
+            app.run()
+
+            output_image = read_image(output_path)
+            np.testing.assert_array_equal(output_image, GREEN_IMAGE)

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -1,13 +1,21 @@
+from io import StringIO
 from pathlib import Path
 from typing import Union
 
 import pytest
+import yaml
 
 from layered_vision.app import LayeredVisionApp
 
 
 def _quote_path(path: Union[str, Path]) -> str:
     return repr(str(path))
+
+
+def _get_yaml_text(data) -> str:
+    out = StringIO()
+    yaml.safe_dump(data, out)
+    return out.getvalue()
 
 
 class TestMain:
@@ -65,3 +73,28 @@ class TestMain:
                 assert not app.output_runtime_layers[0].source_layers[0].source_layers
             else:
                 assert app.output_runtime_layers[0].source_layers[0].source_layers
+
+    def _test_should_reload_input_source_if_changed(self, temp_dir: Path):
+        input_path = temp_dir / 'input.png'
+        input_path_2 = temp_dir / 'input_2.png'
+        output_path = temp_dir / 'output.png'
+        config_file = temp_dir / 'config.yml'
+        config = {
+            'layers': [{
+                'id': 'in',
+                'input_path': str(input_path)
+            }, {
+                'id': 'out',
+                'output_path': str(output_path)
+            }]
+        }
+        config_file.write_text(_get_yaml_text(config))
+        with LayeredVisionApp(str(config_file)) as app:
+            input_layer = app.layer_by_id['in']
+            output_layer = app.layer_by_id['out']
+            assert input_layer.layer_config.get('input_path') == str(input_path)
+            config['layers'][0]['input_path'] = str(input_path_2)
+            config_file.write_text(_get_yaml_text(config))
+            app.reload_config()
+            assert app.layer_by_id['in'].layer_config.get('input_path') == str(input_path_2)
+            assert app.layer_by_id['out'] == output_layer

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -74,7 +74,7 @@ class TestMain:
             else:
                 assert app.output_runtime_layers[0].source_layers[0].source_layers
 
-    def _test_should_reload_input_source_if_changed(self, temp_dir: Path):
+    def test_should_reload_input_source_if_changed(self, temp_dir: Path):
         input_path = temp_dir / 'input.png'
         input_path_2 = temp_dir / 'input_2.png'
         output_path = temp_dir / 'output.png'

--- a/tests/resolved_config_test.py
+++ b/tests/resolved_config_test.py
@@ -1,0 +1,73 @@
+from layered_vision.config import AppConfig, LayerConfig
+from layered_vision.resolved_config import ResolvedAppConfig
+
+
+class TestResolvedAppConfig:
+    def test_should_connect_input_to_output_layer(self):
+        resolved_app_config = ResolvedAppConfig(AppConfig([
+            LayerConfig({
+                'id': 'in',
+                'input_path': 'input_path_1'
+            }),
+            LayerConfig({
+                'id': 'out',
+                'output_path': 'output_path_1'
+            })
+        ]))
+        assert resolved_app_config.layer_by_id['in'].get('input_path') == (
+            'input_path_1'
+        )
+        assert resolved_app_config.layer_by_id['out'].get('output_path') == (
+            'output_path_1'
+        )
+        assert resolved_app_config.layer_by_id['out'].input_layer_ids == ['in']
+
+    def test_should_connect_input_to_branch_layers(self):
+        resolved_app_config = ResolvedAppConfig(AppConfig([
+            LayerConfig({
+                'id': 'in',
+                'input_path': 'input_path_1'
+            }),
+            LayerConfig({
+                'id': 'branches',
+                'branches': [{
+                    'layers': [{
+                        'id': 'branch_1_layer_1',
+                        'filter': 'dummy'
+                    }]
+                }]
+            }),
+            LayerConfig({
+                'id': 'out',
+                'output_path': 'output_path_1'
+            })
+        ]))
+        assert resolved_app_config.layer_by_id['in'].get('input_path') == (
+            'input_path_1'
+        )
+        assert resolved_app_config.layer_by_id['out'].get('output_path') == (
+            'output_path_1'
+        )
+        assert resolved_app_config.layer_by_id['branch_1_layer_1'].input_layer_ids == ['in']
+        assert resolved_app_config.layer_by_id['out'].input_layer_ids == ['branches']
+
+    def test_should_skip_disabled_layers(self):
+        resolved_app_config = ResolvedAppConfig(AppConfig([
+            LayerConfig({
+                'id': 'in1',
+                'enabled': True,
+                'input_path': 'input_path_1'
+            }),
+            LayerConfig({
+                'id': 'in2',
+                'enabled': False,
+                'input_path': 'input_path_1'
+            }),
+            LayerConfig({
+                'id': 'out',
+                'output_path': 'output_path_1'
+            })
+        ]))
+        assert resolved_app_config.layer_by_id['in1']
+        assert not resolved_app_config.layer_by_id.get('in2')
+        assert resolved_app_config.layer_by_id['out'].input_layer_ids == ['in1']

--- a/tests/resolved_config_test.py
+++ b/tests/resolved_config_test.py
@@ -35,6 +35,11 @@ class TestResolvedAppConfig:
                         'id': 'branch_1_layer_1',
                         'filter': 'dummy'
                     }]
+                }, {
+                    'layers': [{
+                        'id': 'branch_2_layer_1',
+                        'filter': 'dummy'
+                    }]
                 }]
             }),
             LayerConfig({
@@ -49,6 +54,10 @@ class TestResolvedAppConfig:
             'output_path_1'
         )
         assert resolved_app_config.layer_by_id['branch_1_layer_1'].input_layer_ids == ['in']
+        assert resolved_app_config.layer_by_id['branch_2_layer_1'].input_layer_ids == ['in']
+        assert resolved_app_config.layer_by_id['branches'].input_layer_ids == [
+            'branch_1_layer_1', 'branch_2_layer_1'
+        ]
         assert resolved_app_config.layer_by_id['out'].input_layer_ids == ['branches']
 
     def test_should_skip_disabled_layers(self):
@@ -62,6 +71,33 @@ class TestResolvedAppConfig:
                 'id': 'in2',
                 'enabled': False,
                 'input_path': 'input_path_1'
+            }),
+            LayerConfig({
+                'id': 'out',
+                'output_path': 'output_path_1'
+            })
+        ]))
+        assert resolved_app_config.layer_by_id['in1']
+        assert not resolved_app_config.layer_by_id.get('in2')
+        assert resolved_app_config.layer_by_id['out'].input_layer_ids == ['in1']
+
+    def test_should_skip_disabled_branch_layers(self):
+        resolved_app_config = ResolvedAppConfig(AppConfig([
+            LayerConfig({
+                'id': 'branches',
+                'branches': [{
+                    'layers': [{
+                        'id': 'in1',
+                        'enabled': True,
+                        'input_path': 'input_path_1'
+                    }]
+                }, {
+                    'layers': [{
+                        'id': 'in2',
+                        'enabled': False,
+                        'input_path': 'input_path_1'
+                    }]
+                }]
             }),
             LayerConfig({
                 'id': 'out',


### PR DESCRIPTION
resolves #68

This also makes the runtime layers simpler, by removing the branches. Instead those are pre-calculated as more explicit resolved config with multiple inputs.

Input and output layers will currently get reloaded completely on change.
Filter layers will get updated with the new config. It may be up to the filter to update some state.