### PR TITLE
added `mp_selfie_segmentation` (MediaPipe) filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         include:
         - python-version: 3.8
           push-package: true

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ when using this project as a library:
 | bodypix    | For [bodypix](https://github.com/de-code/python-tf-bodypix) filter
 | webcam     | Virtual Webcam support via [pyfakewebcam](https://pypi.org/project/pyfakewebcam/)
 | youtube    | YouTube support via [pafy](https://pypi.org/project/pafy/) and [youtube_dl](https://pypi.org/project/youtube_dl/)
+| mediapipe  | Selfie Segmentation using [MediaPipe](https://google.github.io/mediapipe/solutions/selfie_segmentation.html).
 | all        | All of the libraries
 
 ## Virtual Webcam For Linux
@@ -176,13 +177,34 @@ The following filters are currently supported:
 | `erode` | Erodes the image or channel. That could be useful to remove outliers from an alpha mask. |
 | `bilateral` | Applies a [bilateral filter](https://en.wikipedia.org/wiki/Bilateral_filter), using `d`, `sigma_color` and `sigma_space` parameters. |
 | `motion_blur` | Adds a motion blur to the image or channel. That could be used to make an alpha mask move more slowly |
+| `mp_selfie_segmentation` | Uses the [MediaPipe's Selfie Segmentation](https://google.github.io/mediapipe/solutions/selfie_segmentation.html) to mask a person (similar to bodypix). |
 | `pixelate` | Pixelates the input. |
 | `fill` | Fills the input or a selected channel with a color / value. e.g. with `color` set to `blue` |
 | `invert` | Inverts the input. e.g. `black` to `white` |
 | `multiply` | Multiplies the input with a constant value. e.g. to adjust the `alpha` channel |
 | `warp_perspective` | Warps the perspective of the input image given a list of `target_points`. e.g. to display it in a corner of the output image |
 
-Every *filter* may have additional properties. Please refer to the [examples](https://github.com/de-code/layered-vision/tree/develop/example-config) (or come back in the future) for more detailed information. In particular [display-video-bodypix-replace-background-template.yml](https://github.com/de-code/layered-vision/blob/develop/example-config/display-video-bodypix-replace-background-template.yml) provides examples of most filters (often disabled by default).
+Every *filter* may have additional properties. Please refer to the [examples](https://github.com/de-code/layered-vision/tree/develop/example-config) (or come back in the future) for more detailed information. In particular [display-video-segmentation-replace-background-template.yml](https://github.com/de-code/layered-vision/blob/develop/example-config/display-video-segmentation-replace-background-template.yml) provides examples of most filters (often disabled by default).
+
+#### Filter: mp_selfie_segmentation
+
+[MediaPipe's Selfie Segmentation](https://google.github.io/mediapipe/solutions/selfie_segmentation.html) allows background segmentation (similar to bodypix). As it is more optimized, it will usually be faster than using bodypix.
+
+The following parameters are supported:
+
+| name | default value | description |
+| ---- | ------------- | ----------- |
+| `model_selection` | `1`   | The model to use, `0` or `1` (please refer [MediaPipe's Selfie Segmentation documentation](https://google.github.io/mediapipe/solutions/selfie_segmentation.html#model_selection) for further details).
+| `threshold` | `0.1`      | The threshold for the segmentation mask.
+| `cache_model_result_secs` | `0.0`      | The number of seconds to cache the mask for.
+
+```bash
+python -m layered_vision start \
+  --config-file \
+  "example-config/display-video-segmentation-replace-background-template.yml" \
+  --set "bodypix.enabled=false" \
+  --set "mp_selfie_segmentation.enabled=true"
+```
 
 ### Branches Layer
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The following filters are currently supported:
 
 Every *filter* may have additional properties. Please refer to the [examples](https://github.com/de-code/layered-vision/tree/develop/example-config) (or come back in the future) for more detailed information. In particular [display-video-segmentation-replace-background-template.yml](https://github.com/de-code/layered-vision/blob/develop/example-config/display-video-segmentation-replace-background-template.yml) provides examples of most filters (often disabled by default).
 
-#### Filter: mp_selfie_segmentation
+#### Filter: mp_selfie_segmentation (Experimental)
 
 [MediaPipe's Selfie Segmentation](https://google.github.io/mediapipe/solutions/selfie_segmentation.html) allows background segmentation (similar to bodypix). As it is more optimized, it will usually be faster than using bodypix.
 

--- a/example-config/display-video-segmentation-replace-background-template.yml
+++ b/example-config/display-video-segmentation-replace-background-template.yml
@@ -55,6 +55,13 @@ layers:
         internal_resolution: 0.5
         threshold: 0.5
         cache_model_result_secs: 0
+        enabled: true
+      - id: mp_selfie_segmentation
+        filter: mp_selfie_segmentation
+        cache_model_result_secs: 0.0
+        threshold: 0.1
+        model_selection: 1
+        enabled: false
       - id: invert
         filter: invert
         channel: alpha

--- a/layered_vision/filters/mp_selfie_segmentation.py
+++ b/layered_vision/filters/mp_selfie_segmentation.py
@@ -1,0 +1,113 @@
+import logging
+from time import time
+from typing import NamedTuple, Optional, cast
+
+import numpy as np
+import mediapipe as mp
+
+from layered_vision.utils.image import (
+    ImageArray,
+    get_image_with_alpha
+)
+
+from layered_vision.filters.api import AbstractLayerFilter
+from layered_vision.config import LayerConfig
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class BodyPixFilter(AbstractLayerFilter):
+    class Config(NamedTuple):
+        threshold: float
+        model_selection: int
+        cache_model_result_secs: float
+
+    def __init__(self, layer_config: LayerConfig, **kwargs):
+        super().__init__(layer_config, **kwargs)
+        self.mp_selfie_segmentation_config = self.parse_mp_selfie_segmentation_config(
+            layer_config
+        )
+        self._selfie_segmentation: Optional[
+            mp.solutions.selfie_segmentation.SelfieSegmentation
+        ] = None
+        self._mask_cache: Optional[np.ndarray] = None
+        self._mask_cache_time: float = 0
+
+    def parse_mp_selfie_segmentation_config(self, layer_config: LayerConfig) -> Config:
+        config = BodyPixFilter.Config(
+            threshold=layer_config.get_float('threshold', 0.50),
+            model_selection=layer_config.get_int('model_selection', 1),
+            cache_model_result_secs=(
+                layer_config.get_float('cache_model_result_secs', 0.0)
+            )
+        )
+        LOGGER.info('mp selfie segmentation filter config: %s', config)
+        return config
+
+    def on_config_changed(self, layer_config: LayerConfig):
+        super().on_config_changed(layer_config)
+        mp_selfie_segmentation_config = self.parse_mp_selfie_segmentation_config(layer_config)
+        if (
+            mp_selfie_segmentation_config.model_selection
+            != self.mp_selfie_segmentation_config.model_selection
+        ):
+            # we need to reload the model
+            self.unload_selfie_segmentation()
+        self.mp_selfie_segmentation_config = mp_selfie_segmentation_config
+
+    def load_selfie_segmentation(self) -> mp.solutions.selfie_segmentation.SelfieSegmentation:
+        LOGGER.info('loading selfie segmentation: %s', self.mp_selfie_segmentation_config)
+        selfie_segmentation = mp.solutions.selfie_segmentation.SelfieSegmentation(
+            model_selection=self.mp_selfie_segmentation_config.model_selection
+        )
+        selfie_segmentation.__enter__()
+        return selfie_segmentation
+
+    @property
+    def selfie_segmentation(self) -> mp.solutions.selfie_segmentation.SelfieSegmentation:
+        if self._selfie_segmentation is None:
+            self._selfie_segmentation = self.load_selfie_segmentation()
+        return self._selfie_segmentation
+
+    def unload_selfie_segmentation(self):
+        if self._selfie_segmentation is not None:
+            LOGGER.info('unloading selfie segmentation')
+            self._selfie_segmentation.__exit__(None, None, None)
+            self._selfie_segmentation = None
+            self._mask_cache = None
+
+    def close(self):
+        self.unload_selfie_segmentation()
+        super().close()
+
+    def get_segmentation_mask(self, image_array: ImageArray) -> np.ndarray:
+        current_time = time()
+        if (
+            self._mask_cache is not None
+            and current_time < (
+                self._mask_cache_time + self.mp_selfie_segmentation_config.cache_model_result_secs
+            )
+        ):
+            return self._mask_cache
+        segmentation_result: 'mp.solutions.SolutionOutputs' = (
+            self.selfie_segmentation.process(image_array)
+        )
+        self._mask_cache = segmentation_result.segmentation_mask
+        self._mask_cache_time = current_time
+        return self._mask_cache
+
+    def do_filter(self, image_array: ImageArray) -> ImageArray:
+        mask = self.get_segmentation_mask(image_array)
+        mask = cast(
+            ImageArray,
+            (mask >= self.mp_selfie_segmentation_config.threshold) * 255.0
+        )
+        LOGGER.debug('mask.shape: %s', mask.shape)
+        return get_image_with_alpha(
+            image_array,
+            mask
+        )
+
+
+FILTER_CLASS = BodyPixFilter

--- a/layered_vision/filters/mp_selfie_segmentation.py
+++ b/layered_vision/filters/mp_selfie_segmentation.py
@@ -36,7 +36,7 @@ class BodyPixFilter(AbstractLayerFilter):
 
     def parse_mp_selfie_segmentation_config(self, layer_config: LayerConfig) -> Config:
         config = BodyPixFilter.Config(
-            threshold=layer_config.get_float('threshold', 0.50),
+            threshold=layer_config.get_float('threshold', 0.1),
             model_selection=layer_config.get_int('model_selection', 1),
             cache_model_result_secs=(
                 layer_config.get_float('cache_model_result_secs', 0.0)

--- a/layered_vision/utils/dist.py
+++ b/layered_vision/utils/dist.py
@@ -1,4 +1,4 @@
-def get_requirement_groups(requirement):
+def get_requirement_groups(requirement):  # pylint: disable=too-many-return-statements
     requirement_lower = requirement.lower()
     if 'bodypix' in requirement_lower:
         return ['bodypix']
@@ -10,6 +10,8 @@ def get_requirement_groups(requirement):
         return ['youtube']
     if 'mss' in requirement_lower:
         return ['mss']
+    if 'mediapipe' in requirement_lower:
+        return ['mediapipe']
     return [None]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.0.1
-mediapipe==0.8.6
+mediapipe>=0.8.3
 mss==6.1.0
 numpy==1.19.5
 opencv-python==4.5.2.54

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.0.1
-mediapipe>=0.8.3
+mediapipe>=0.8.5
 mss==6.1.0
 numpy>=1.19.3,<1.20.0
 opencv-python==4.5.2.54

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==2.0.1
 mediapipe>=0.8.3
 mss==6.1.0
-numpy==1.19.5
+numpy>=1.19.3,<1.20.0
 opencv-python==4.5.2.54
 pafy==0.5.5
 pyfakewebcam==0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==2.0.1
 mediapipe>=0.8.5
 mss==6.1.0
-numpy>=1.19.3,<1.20.0
+numpy>=1.19.3,<1.22.0
 opencv-python==4.5.2.54
 pafy==0.5.5
 pyfakewebcam==0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask==2.0.1
+mediapipe==0.8.6
 mss==6.1.0
 numpy==1.19.5
 opencv-python==4.5.2.54

--- a/tests/example_config_test.py
+++ b/tests/example_config_test.py
@@ -87,3 +87,25 @@ class TestMain:
         main(['start', '--config-file=%s' % config_file])
         sink = get_image_output_sink_for_path_mock.last_sink
         assert len(sink.images) > 0
+
+    @pytest.mark.parametrize("example_config_filename,additional_args", [
+        (
+            'display-video-segmentation-replace-background-template.yml',
+            [
+                '--set=bodypix.enabled=false',
+                '--set=mp_selfie_segmentation.enabled=false'
+            ]
+        )
+    ])
+    def test_should_process_example_with_args(
+            self,
+            example_config_filename: str,
+            additional_args: List[str],
+            get_image_output_sink_for_path_mock: GetCapturingOutputSink):
+        config_file = Path(EXAMPLE_CONFIG_DIR) / example_config_filename
+        main(
+            ['start', '--config-file=%s' % config_file]
+            + additional_args
+        )
+        sink = get_image_output_sink_for_path_mock.last_sink
+        assert len(sink.images) > 0


### PR DESCRIPTION
Added a segmentation filter using [MediaPipe's Selfie Segmentation](https://google.github.io/mediapipe/solutions/selfie_segmentation.html#model_selection).

Had to drop Python 3.6 for this.
As the Selfie Segmentation is only in MediaPipe `0.8.5` and above. But the last MediaPipe version with Python 3.6 support is `0.8.3`.