### PR TITLE
hardcode docker image repo name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Set tags
         id: set_tags
         run: |
-          DOCKER_IMAGE=${{ secrets.DOCKERHUB_USERNAME }}/layered-vision
+          DOCKER_IMAGE=de4code/layered-vision
           VERSION=""
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}


### PR DESCRIPTION
When secrets are not available for some PRs, we still want to build the docker image. Using the secret for the image username / repo caused it to fail.