### PR TITLE
bump mediapipe to 0.8.7.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.0.1
-mediapipe>=0.8.5
+mediapipe>=0.8.7.1
 mss==6.1.0
 numpy>=1.19.3,<1.22.0
 opencv-python==4.5.3.56


### PR DESCRIPTION
this seem to include a GIL fix (no more crashes)