### PR TITLE
fixed pypi badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Layered Vision
 
-[![PyPi version](https://pypip.in/v/layered-vision/badge.png)](https://pypi.org/project/layered-vision/)
+[![PyPi version](https://img.shields.io/pypi/v/layered-vision)](https://pypi.org/project/layered-vision/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Goals of this project is:


### PR DESCRIPTION
The `pypip.in` URL doesn't seem to work anymore, switching to `shields.io`.

(Same as https://github.com/de-code/python-tf-bodypix/pull/145)