### PR TITLE
downgraded to GitHub windows-2019 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         include:
         - python-version: 3.8
           push-package: true
-        - os: windows-latest
+        - os: windows-2019
           python-version: 3.8
         - os: macos-latest
           python-version: 3.8


### PR DESCRIPTION
This is because the pip install is taking too long and constraints didn't seem to have helped.